### PR TITLE
fix aspect ratio of photos on smartphone

### DIFF
--- a/gustav/gustav.css
+++ b/gustav/gustav.css
@@ -630,6 +630,7 @@ div.category ul {
 		float: none;
 		margin: 10px auto;
 		max-width: 300px !important;
+		height: auto;
 	}
 
 	div.section img.amazon {
@@ -659,4 +660,3 @@ div.category ul {
 		display: none;
 	}
 }
-


### PR DESCRIPTION
スマートフォンでの閲覧時に画像のアスペクト比が崩れて表示されています。`max-width: 300px !important;` で横幅を縮小しているのに、高さを指定していないのが原因のようです。高さも指定することで、正しいアスペクト比で表示されます。