### PR TITLE
Change background-size to the size of whole-content for smart phones.

### DIFF
--- a/gustav/gustav.css
+++ b/gustav/gustav.css
@@ -582,8 +582,8 @@ div.category ul {
 @media screen and (max-device-width: 480px) {
 	body {
 		background-image: url(gustav_back_iphone.jpg);
-		background-position: left top;
-		background-size: contain;
+		background-position: center top;
+		background-size: 95%;
 		box-sizing: border-box;
 	}
 


### PR DESCRIPTION
Otherwise, the background image sticks out of adminmenu.
